### PR TITLE
Harden Docker deployment with Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Host-side listener settings
+OHDIEUX_BIND_ADDRESS=0.0.0.0
+OHDIEUX_PORT=8080
+
+# Public URL used in generated archive links
+PUBLIC_URL=http://localhost:8080
+
+# Optional media archival
+ARCHIVE_MEDIA=false
+MANIFEST_SERVE_IMAGES=false
+MANIFEST_SERVE_MEDIA=false
+
+# Disable this when exposing an archive-backed deployment publicly
+SCRAPER_AUTO_ADD_PROGRAMME=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 logs
 target
 /.bsp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,45 @@
-FROM eclipse-temurin:21-jdk-alpine as build
+FROM eclipse-temurin:21-jdk-alpine AS build
 
-RUN apk update
-RUN apk add curl bash
-RUN curl -fL https://github.com/coursier/coursier/releases/download/v2.1.24/coursier > /usr/local/bin/cs
-RUN chmod +x /usr/local/bin/cs
-RUN cs install --dir /usr/local/bin scalac:3.5.1 sbt:1.10.2
-
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash curl \
+  && curl -fL https://github.com/coursier/coursier/releases/download/v2.1.24/coursier -o /usr/local/bin/cs \
+  && chmod +x /usr/local/bin/cs \
+  && cs install --dir /usr/local/bin scalac:3.5.1 sbt:1.10.2
 
 WORKDIR /app
-COPY build.sbt .
-COPY project project
-RUN sbt update
+COPY build.sbt ./
+COPY project ./project
+RUN sbt -batch update
 
-COPY src /app/src
-RUN sbt playUpdateSecret
-RUN sbt dist
+COPY src ./src
+RUN sbt -batch playUpdateSecret >/dev/null \
+  && sbt -batch stage
 
 FROM eclipse-temurin:21-jre-alpine
 
-RUN apk add bash ffmpeg
-WORKDIR /app
-COPY --from=build /app/target/universal/*.zip .
-RUN unzip *.zip -d ohdieux/
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash ffmpeg \
+  && addgroup -S -g 2000 ohdieux \
+  && adduser -S -D -H -u 2000 -G ohdieux ohdieux
 
-RUN mkdir -p /tmp/ohdieux /data
-RUN chown 2000:2000 /tmp/ohdieux /data
+WORKDIR /app
+COPY --from=build --chown=ohdieux:ohdieux /app/target/universal/stage /app/ohdieux
+RUN mkdir -p /tmp/ohdieux /data \
+  && chown -R ohdieux:ohdieux /tmp/ohdieux /data
+
+ENV PORT=8080 \
+    HTTP_ADDRESS=0.0.0.0 \
+    DATA_DIR=/data/ \
+    ARCHIVE_TEMP_DIR=/tmp/ohdieux
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+  CMD ["sh", "-c", "wget -q --spider \"http://127.0.0.1:${PORT}/health\""]
 
 USER 2000:2000
 WORKDIR /data
 
-CMD [ "/app/ohdieux/bin/ohdieux", \
+CMD ["/app/ohdieux/bin/ohdieux", \
   "-Dpidfile.path=/tmp/ohdieux.pid", \
-  "-Dlogger.resource=prod-logback.xml", \
-  "-Dbase_data_dir=/data/" \
-  ]
+  "-Dlogger.resource=prod-logback.xml"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,25 @@
+services:
+  ohdieux:
+    image: ${OHDIEUX_IMAGE:-ohdieux:latest}
+    build:
+      context: .
+    restart: unless-stopped
+    init: true
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - "${OHDIEUX_BIND_ADDRESS:-0.0.0.0}:${OHDIEUX_PORT:-8080}:8080"
+    environment:
+      PORT: "8080"
+      HTTP_ADDRESS: "0.0.0.0"
+      DATA_DIR: "/data/"
+      PUBLIC_URL: "${PUBLIC_URL:-http://localhost:8080}"
+      ARCHIVE_MEDIA: "${ARCHIVE_MEDIA:-false}"
+      MANIFEST_SERVE_IMAGES: "${MANIFEST_SERVE_IMAGES:-false}"
+      MANIFEST_SERVE_MEDIA: "${MANIFEST_SERVE_MEDIA:-false}"
+      SCRAPER_AUTO_ADD_PROGRAMME: "${SCRAPER_AUTO_ADD_PROGRAMME:-true}"
+    volumes:
+      - ohdieux-data:/data
+
+volumes:
+  ohdieux-data:

--- a/docs/DEPLOIEMENT.md
+++ b/docs/DEPLOIEMENT.md
@@ -1,71 +1,84 @@
 # Déploiement autogéré
 
 ## Déploiement de base
-Ce déploiement est adéquat pour un environment local. Voir [Considérations de
-production](#considérations-de-production) pour configurer un
-déploiment de production.
 
-0. Créer l'image docker
-```bash
-docker build . -t ohdieux:latest
-```
-1. Créer un container docker
-```bash
-docker run --restart always \
-  -p 8080:8080 \
-  -e PORT=8080 \
-  -e PUBLIC_URL="http://<my-accessible-ip>:8080" \
-  -v ./data:/data \
-  --name ohdieux \
-  ohdieux:latest
-```
-2. Rendez vous au `http://localhost:8080/admin` pour ajouter de
-   nouveaux programmes.
+Ce déploiement est adéquat pour un environnement local. Voir [Considérations de
+production](#considérations-de-production) pour configurer un
+déploiement de production.
+
+1. Créez le fichier d'environnement local et configurez `PUBLIC_URL` avec
+   l'URL depuis laquelle les utilisateurs accéderont à Ohdieux.
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Construisez et démarrez le service.
+
+   ```bash
+   docker compose up -d --build
+   ```
+
+3. Vérifiez que le conteneur est sain.
+
+   ```bash
+   docker compose ps
+   ```
+
+4. Rendez-vous au `http://localhost:8080/admin` pour ajouter de nouveaux
+   programmes.
+
+Compose stocke la base de données et les fichiers archivés dans le volume nommé
+`ohdieux-data`. `docker compose down` conserve ce volume; `docker compose down
+-v` le supprime définitivement.
 
 ## Déploiement simple (avec archive média)
+
 Ce déploiement sauvegarde les fichiers audio de chaque épisode découvert.
-**Assurez-vous d'avoir beaucoup d'espace de disque disponible.***
+**Assurez-vous d'avoir beaucoup d'espace disque disponible.**
+
+Configurez les valeurs suivantes dans `.env`, puis recréez le service :
+
+```dotenv
+ARCHIVE_MEDIA=true
+MANIFEST_SERVE_IMAGES=true
+MANIFEST_SERVE_MEDIA=true
+SCRAPER_AUTO_ADD_PROGRAMME=false
+```
 
 ```bash
-docker run --restart always \
-  -p 8080:8080 \
-  -e PORT=8080 \
-  -e PUBLIC_URL="http://<my-accessible-ip>:8080" \
-  -e ARCHIVE_MEDIA=true \
-  -e MANIFEST_SERVE_IMAGES=true \
-  -e MANIFEST_SERVE_MEDIA=true \
-  -v ./data:/data \
-  --name ohdieux \
-  ohdieux:latest
+docker compose up -d
 ```
 
 ## Considérations de production
-* Le tableau de bord d'administrateur est disponible sous le chemin
+
+- Le tableau de bord d'administrateur est disponible sous le chemin
   `/admin` **sans authentification**. Assurez-vous de restreindre
   l'accès au routes sous `/admin/**` si votre serveur est exposé à l'internet.
-  ```
+
+  ```nginx
   # exemple pour nginx
   location ~* /admin {
       return 403;
   }
   ```
-  
-* Par défaut, Ohdieux ajoute à sa base de données tous les programmes
+
+- Par défaut, Ohdieux ajoute à sa base de données tous les programmes
   demandés sur la route `/rss`. Si vous utilisez la fonctionnalité
   d'archivage média, il est **fortement recommandé** de désactiver
   cette fonctionnalité en assignant la valeur `false` à la variable
   `SCRAPER_AUTO_ADD_PROGRAMME` pour éviter de remplir votre disque dur.
 
-* Par défault, Ohdieux utilise une base de données SQLite. Considérez
+- Par défault, Ohdieux utilise une base de données SQLite. Considérez
   l'utilisation d'un autre pilote JDBC ou un _load balancer_ avec une
   fonction de cache pour servir un grand nombre de requêtes.
 
-
 ## Variables d'environnement
+
 Les variables d'environnement sont définies dans [application.conf](/src/main/resources/application.conf).
 
 | Environment variable        | Description                                                                               | Default value                             |
-|-----------------------------|-------------------------------------------------------------------------------------------|-------------------------------------------|
+| --------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------- |
 | PORT                        | Port d'écoute                                                                             | 9000                                      |
 | HTTP_ADDRESS                | Address réseau d'écoute                                                                   | 0.0.0.0                                   |
 | DATA_DIR                    | Dossier de base pour les données locales.                                                 | `./` localement, `/data/` dans docker.    |
@@ -87,6 +100,3 @@ Les variables d'environnement sont définies dans [application.conf](/src/main/r
 | MANIFEST_SERVE_MEDIA        | Servir les fichiers audio depuis l'archive locale. (true/false)                           | `false`                                   |
 | MANIFEST_IMAGE_BASE_URL     | Configuration manuelle de l'URL de base pour les images à servir (déploiements avancés)   | `${PUBLIC_URL}/media/image/`              |
 | MANIFEST_AUDIO_BASE_URL     | Configuration manuelle de l'URL de base pour les fichiers audio (déploiement avancés)     | `${PUBLIC_URL}/media/audio/`              |
-
-
-

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,70 +1,83 @@
 # Self-hosted Deployment
 
 ## Basic Deployment
+
 This setup is fine for simple local deployments. See [Production
 Considerations](#production-considerations) to configure a production
 deployment.
 
-0. Build the docker image.
-```bash
-docker build . -t ohdieux:latest
-```
-1. Run a basic docker installation.
-```bash
-docker run --restart always \
-  -p 8080:8080 \
-  -e PORT=8080 \
-  -e PUBLIC_URL="http://<my-accessible-ip>:8080" \
-  -v ./data:/data \
-  --name ohdieux \
-  ohdieux:latest
-```
-2. Head over to `http://localhost:8080/admin` to start adding programmes.
+1. Create the local environment file and set `PUBLIC_URL` to the URL from
+   which users will access Ohdieux.
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Build and start the service.
+
+   ```bash
+   docker compose up -d --build
+   ```
+
+3. Check that the container is healthy.
+
+   ```bash
+   docker compose ps
+   ```
+
+4. Head over to `http://localhost:8080/admin` to start adding programmes.
+
+Compose stores the database and archived files in the `ohdieux-data` named
+volume. `docker compose down` preserves this volume; `docker compose down -v`
+permanently deletes it.
 
 ## Simple Deployment (with media archival)
+
 This deployment will save the audio files for every episode.
-**Ensure that you have a large amount of hard drive space.***
+**Ensure that you have a large amount of hard drive space.**
+
+Set the following values in `.env`, then recreate the service:
+
+```dotenv
+ARCHIVE_MEDIA=true
+MANIFEST_SERVE_IMAGES=true
+MANIFEST_SERVE_MEDIA=true
+SCRAPER_AUTO_ADD_PROGRAMME=false
+```
 
 ```bash
-docker run --restart always \
-  -p 8080:8080 \
-  -e PORT=8080 \
-  -e PUBLIC_URL="http://<my-accessible-ip>:8080" \
-  -e ARCHIVE_MEDIA=true \
-  -e MANIFEST_SERVE_IMAGES=true \
-  -e MANIFEST_SERVE_MEDIA=true \
-  -v ./data:/data \
-  --name ohdieux \
-  ohdieux:latest
+docker compose up -d
 ```
 
 ## Production Considerations
-* The admin dashboard is available on `/admin` **without any
+
+- The admin dashboard is available on `/admin` **without any
   authentication**. Therefore, if exposing to the internet, you should
-  forbid unauthenticated requests to `/admin/**`. 
-  ```
+  forbid unauthenticated requests to `/admin/**`.
+
+  ```nginx
   # nginx example
   location ~* /admin {
       return 403;
   }
   ```
-  
-* By default, Ohdieux is set to start tracking every queried
+
+- By default, Ohdieux is set to start tracking every queried
   manifest. If you are using the media archive, it is **highly
   recommended** to disable this setting by setting
   `SCRAPER_AUTO_ADD_PROGRAMME` to `false` to avoid filling up your
   hard drive.
 
-* By default, Ohdieux uses an SQLite database. Consider using another
+- By default, Ohdieux uses an SQLite database. Consider using another
   JDBC driver or a caching load balancer if serving a large number of
   requests.
 
-
 ## Environment Variables
+
 Environment variables are defined and used in [application.conf](/src/main/resources/application.conf).
 
 | Environment variable        | Description                                                                       | Default value                       |
-|-----------------------------|-----------------------------------------------------------------------------------|-------------------------------------|
+| --------------------------- | --------------------------------------------------------------------------------- | ----------------------------------- |
 | PORT                        | Listening port                                                                    | 9000                                |
 | HTTP_ADDRESS                | Binding address                                                                   | 0.0.0.0                             |
 | DATA_DIR                    | Global default data directory.                                                    | `./` locally, `/data/` in docker.   |
@@ -86,6 +99,3 @@ Environment variables are defined and used in [application.conf](/src/main/resou
 | MANIFEST_SERVE_MEDIA        | Whether to serve audio files from archive instead of upstream CDN. (true/false)   | `false`                             |
 | MANIFEST_IMAGE_BASE_URL     | Override image archive public URL. (Advanced deployments only.)                   | `${PUBLIC_URL}/media/image/`        |
 | MANIFEST_AUDIO_BASE_URL     | Override audio archive public URL. (Advanced deployments only.)                   | `${PUBLIC_URL}/media/audio/`        |
-
-
-


### PR DESCRIPTION
## Summary

- add a Docker Compose deployment with health checks, restart handling, and a persistent named volume
- harden the runtime image and reduce its size by staging the Play distribution directly
- document environment setup and media archival in English and French

## Testing

- `docker build --check .`
- `docker compose config --quiet`
- built and started the Compose service until healthy
- verified `/health` returns `healthy`
- verified SQLite data survives container recreation
